### PR TITLE
Add endpoint for webinar signup's user/account creation

### DIFF
--- a/gc_registry/user/models.py
+++ b/gc_registry/user/models.py
@@ -29,7 +29,3 @@ class User(UserBase, utils.ActiveRecord, table=True):
     accounts: list["Account"] | None = Relationship(
         back_populates="users", link_model=UserAccountLink
     )
-    organisation: str | None = Field(
-        default=None,
-        description="The organisation to which the user is registered.",
-    )

--- a/gc_registry/user/routes.py
+++ b/gc_registry/user/routes.py
@@ -17,11 +17,11 @@ from gc_registry.core.database import db, events
 from gc_registry.core.models.base import UserRoles
 from gc_registry.user.models import User, UserAccountLink
 from gc_registry.user.schemas import (
+    CreateTestAccount,
+    CreateTestAccountResponse,
     UserCreate,
     UserRead,
     UserUpdate,
-    WebinarSignup,
-    WebinarSignupResponse,
 )
 from gc_registry.user.validation import validate_user_role
 
@@ -147,14 +147,14 @@ def change_role(
     return user.update(role_update, write_session, read_session, esdb_client)
 
 
-@router.post("/create_webinar_signup")
-def create_webinar_signup(
-    webinar_signup: WebinarSignup,
+@router.post("/create_test_account")
+def create_test_account(
+    webinar_signup: CreateTestAccount,
     current_user: User = Depends(get_current_active_admin),
     write_session: Session = Depends(db.get_write_session),
     read_session: Session = Depends(db.get_read_session),
     esdb_client: EventStoreDBClient = Depends(events.get_esdb_client),
-) -> WebinarSignupResponse:
+) -> CreateTestAccountResponse:
     """For internal use only.
 
     Given a user who has signed up post-webinar for a test account, perform the following actions:
@@ -227,7 +227,7 @@ def create_webinar_signup(
         white_list_link_dict_send, write_session, read_session, esdb_client
     )
 
-    return WebinarSignupResponse(
+    return CreateTestAccountResponse(
         user=UserRead.model_validate(user.model_dump()),
         account=AccountRead.model_validate(account.model_dump()),
         password=random_password,

--- a/gc_registry/user/routes.py
+++ b/gc_registry/user/routes.py
@@ -1,16 +1,28 @@
+import secrets
 from typing import Annotated
 
 from esdbclient import EventStoreDBClient
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
+from gc_registry.account.models import Account, AccountWhitelistLink
 from gc_registry.account.schemas import AccountRead
 from gc_registry.account.services import get_accounts_by_user_id
-from gc_registry.authentication.services import get_current_user
+from gc_registry.authentication.services import (
+    get_current_active_admin,
+    get_current_user,
+    get_password_hash,
+)
 from gc_registry.core.database import db, events
 from gc_registry.core.models.base import UserRoles
-from gc_registry.user.models import User
-from gc_registry.user.schemas import UserBase, UserRead, UserUpdate
+from gc_registry.user.models import User, UserAccountLink
+from gc_registry.user.schemas import (
+    UserCreate,
+    UserRead,
+    UserUpdate,
+    WebinarSignup,
+    WebinarSignupResponse,
+)
 from gc_registry.user.validation import validate_user_role
 
 # Router initialisation
@@ -23,13 +35,14 @@ LoggedInUser = Annotated[User, Depends(get_current_user)]
 
 @router.post("/create", response_model=UserRead)
 def create_user(
-    user_base: UserBase,
+    user_base: UserCreate,
     current_user: User = Depends(get_current_user),
     write_session: Session = Depends(db.get_write_session),
     read_session: Session = Depends(db.get_read_session),
     esdb_client: EventStoreDBClient = Depends(events.get_esdb_client),
 ):
     validate_user_role(current_user, required_role=UserRoles.ADMIN)
+    user_base.hashed_password = get_password_hash(user_base.password)
     user = User.create(user_base, write_session, read_session, esdb_client)
 
     return user
@@ -132,3 +145,82 @@ def change_role(
     user = User.by_id(user_id, write_session)
     role_update = UserUpdate(role=role)
     return user.update(role_update, write_session, read_session, esdb_client)
+
+
+@router.post("/create_webinar_signup")
+def create_webinar_signup(
+    webinar_signup: WebinarSignup,
+    current_user: User = Depends(get_current_active_admin),
+    write_session: Session = Depends(db.get_write_session),
+    read_session: Session = Depends(db.get_read_session),
+    esdb_client: EventStoreDBClient = Depends(events.get_esdb_client),
+) -> WebinarSignupResponse:
+    """For internal use only.
+
+    Given a user who has signed up post-webinar for a test account, perform the following actions:
+
+    1. Create a new user in the database with the email address of the webinar signup.
+    2. Create a new empty account for this user.
+    3. Give this user access to the central test account that recieves the daily Elexon issuances.
+    4. Whitelist this user's own account to the central test account to allow transfer actions.
+
+    Returns the user and account details, as well as the password to be returned to the user.
+    """
+
+    # Create a random password for the user
+    random_password = secrets.token_urlsafe(12)
+
+    user_base = UserCreate(
+        email=webinar_signup.email,
+        name=webinar_signup.name,
+        organisation=webinar_signup.organisation,
+        password=random_password,
+        role=UserRoles.PRODUCTION_USER,
+    )
+
+    user = User.create(user_base, write_session, read_session, esdb_client)[0]
+
+    # Create a new empty account for the user
+    account_dict = {
+        "account_name": f"{webinar_signup.name}'s Account",
+        "user_ids": [user.id],
+    }
+    account = Account.create(account_dict, write_session, read_session, esdb_client)[0]
+
+    # Retrieve the central test account
+    central_test_account = Account.by_name("Test Account", read_session)
+
+    # Link the user to both their own account and the central test account
+    user_account_link_dict_own = {"user_id": user.id, "account_id": account.id}
+    user_account_link_dict_central = {
+        "user_id": user.id,
+        "account_id": central_test_account.id,
+    }
+    _ = UserAccountLink.create(
+        user_account_link_dict_own, write_session, read_session, esdb_client
+    )
+    _ = UserAccountLink.create(
+        user_account_link_dict_central, write_session, read_session, esdb_client
+    )
+
+    # Whitelist the user's own account to the central test account
+    white_list_link_dict_recieve = {
+        "target_account_id": account.id,
+        "source_account_id": central_test_account.id,
+    }
+    white_list_link_dict_send = {
+        "target_account_id": central_test_account.id,
+        "source_account_id": account.id,
+    }
+    _ = AccountWhitelistLink.create(
+        white_list_link_dict_recieve, write_session, read_session, esdb_client
+    )
+    _ = AccountWhitelistLink.create(
+        white_list_link_dict_send, write_session, read_session, esdb_client
+    )
+
+    return WebinarSignupResponse(
+        user=user,
+        account=account,
+        password=random_password,
+    )

--- a/gc_registry/user/schemas.py
+++ b/gc_registry/user/schemas.py
@@ -71,13 +71,13 @@ class UserRead(BaseModel):
         }
 
 
-class WebinarSignup(BaseModel):
+class CreateTestAccount(BaseModel):
     email: str
     name: str
     organisation: str
 
 
-class WebinarSignupResponse(BaseModel):
+class CreateTestAccountResponse(BaseModel):
     user: UserRead
     account: AccountRead
     password: str

--- a/gc_registry/user/schemas.py
+++ b/gc_registry/user/schemas.py
@@ -20,7 +20,14 @@ class UserBase(BaseModel):
                        and 'Production User'. The roles are used to determine the actions that the User is allowed
                        to perform within the registry, according to the EnergyTag Standard.""",
     )
-    hashed_password: str | None = None
+    hashed_password: str | None = Field(
+        default=None,
+        description="The hashed password of the user.",
+    )
+    organisation: str | None = Field(
+        default=None,
+        description="The organisation to which the user is registered.",
+    )
     is_deleted: bool = Field(default=False)
 
     @field_validator("email")
@@ -28,6 +35,10 @@ class UserBase(BaseModel):
         if not re.match(r"[^@]+@[^@]+\.[^@]+", v):
             raise ValueError("Please enter a valid email address.")
         return v
+
+
+class UserCreate(UserBase):
+    password: str
 
 
 class UserUpdate(BaseModel):
@@ -58,3 +69,15 @@ class UserRead(BaseModel):
             else None,
             "organisation": self.organisation,
         }
+
+
+class WebinarSignup(BaseModel):
+    email: str
+    name: str
+    organisation: str
+
+
+class WebinarSignupResponse(BaseModel):
+    user: UserRead
+    account: AccountRead
+    password: str

--- a/gc_registry/utils.py
+++ b/gc_registry/utils.py
@@ -47,7 +47,10 @@ class ActiveRecord(SQLModel):
     @classmethod
     def create(
         cls,
-        source: list[dict[Hashable, Any]] | dict[Hashable, Any] | BaseModel,
+        source: list[dict[Hashable, Any]]
+        | dict[Hashable, Any]
+        | dict[str, Any]
+        | BaseModel,
         write_session: Session,
         read_session: Session,
         esdb_client: EventStoreDBClient,


### PR DESCRIPTION
## Description

Adds an admin-only endpoint for creating users and accounts for webinar singups:
    1. Create a new user in the database with the email address of the webinar signup.
    2. Create a new empty account for this user.
    3. Give this user access to the central test account that recieves the daily Elexon issuances.
    4. Whitelist this user's own account to the central test account to allow transfer actions.

Returns the user and account details, as well as the randomly-generated password to be returned to the user.

## Has This Been Tested?

- [ ] Yes

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
