### PR TITLE
Feature/gc lineage tracking

### DIFF
--- a/frontend/src/api/certificateAPI.js
+++ b/frontend/src/api/certificateAPI.js
@@ -40,5 +40,5 @@ export const downloadSelectedCertificateAPI = (certificateId) => {
 };
 
 export const getCertificateLineageAPI = (certificateId, format = "timeline") => {
-  return baseAPI.get(`/certificate/lineage/${certificateId}?format=${format}`);
+  return baseAPI.get(`/certificate/${certificateId}/lineage?format=${format}`);
 };

--- a/frontend/src/api/certificateAPI.js
+++ b/frontend/src/api/certificateAPI.js
@@ -38,3 +38,7 @@ export const downloadCertificatesAPI = (queryData) => {
 export const downloadSelectedCertificateAPI = (certificateId) => {
   return baseAPI.get(`/certificate/${certificateId}`);
 };
+
+export const getCertificateLineageAPI = (certificateId, format = "timeline") => {
+  return baseAPI.get(`/certificate/lineage/${certificateId}?format=${format}`);
+};

--- a/frontend/src/components/Certificate/CertificateLineageDialog.js
+++ b/frontend/src/components/Certificate/CertificateLineageDialog.js
@@ -46,9 +46,9 @@ const classify = (e) => {
 
   if (e.event_type === "CREATE") {
     if (e.parent_entity_id != null) {
-      if (e.parent_entity_id.startsWith("S-")) {
+      if (e.kind === "time_shifted") {
         return {
-          label: `Time-shifted: child #${e.entity_id} from #${e.parent_entity_id}`,
+          label: `Time-shifted: #${e.entity_id} from #${e.parent_entity_id}`,
           color: "blue",
         };
       } else {
@@ -158,7 +158,7 @@ const CertificateLineageDialog = ({ open, onClose, lineage }) => {
             .map((e) => ({
             from: e.parent_entity_id,
             to: e.entity_id,
-            type: e.parent_entity_id.startsWith("S-") ? "time_shift" : "split",
+            type: e.kind === "time_shifted" ? "time_shift" : "split",
           })),
       },
     };

--- a/frontend/src/components/Certificate/CertificateLineageDialog.js
+++ b/frontend/src/components/Certificate/CertificateLineageDialog.js
@@ -1,0 +1,140 @@
+import React, { useMemo } from "react";
+import { Modal, Timeline, Typography, Tag } from "antd";
+
+const { Text } = Typography;
+
+const statusColor = (status) => {
+  switch (status) {
+    case "Cancelled":
+      return "red";
+    case "Cancelled for Storage":
+      return "orange";
+    case "Claimed":
+      return "green";
+    case "Reserved":
+      return "gold";
+    case "Locked":
+      return "gray";
+    case "Withdrawn":
+      return "gray";
+    case "Bundle Split":
+      return "purple";
+    case "Active":
+      return "green";
+    default:
+      return "blue";
+  }
+};
+
+const normalizeDiffs = (diffs) => {
+    if (Array.isArray(diffs)) return diffs;
+    if (diffs && typeof diffs == "object") {
+        return Object.entries(diffs).map(([field, v]) => ({
+            field,
+            before: v?.before,
+            after: v?.after,
+        }));
+    }
+    return [];
+};
+
+const classify = (e) => {
+  const diffs = normalizeDiffs(e.diffs);
+  const diffMap = Object.fromEntries(
+    diffs.map((d) => [d.field, { before: d.before, after: d.after }])
+  );
+
+  if (e.event_type === "CREATE") {
+    if (e.parent_entity_id != null) {
+      return {
+        label: `Split: child #${e.entity_id} from #${e.parent_entity_id}`,
+        color: "purple",
+      };
+    }
+    return { label: `Bundle created #${e.entity_id}`, color: "green" };
+  }
+  if (e.event_type === "DELETE") {
+    return { label: `Bundle #${e.entity_id} deleted`, color: "red" };
+  }
+  if (e.event_type === "UPDATE") {
+    if (diffMap.account_id) {
+      const { before, after } = diffMap.account_id;
+      return {
+        label: `Transferred: account ${before} → ${after}`,
+        color: "blue",
+      };
+    }
+    if (diffMap.certificate_bundle_status) {
+      const { after } = diffMap.certificate_bundle_status;
+      return { label: `Status: ${after}`, color: statusColor(after) };
+    }
+    return { label: "Bundle updated", color: "gray" };
+  }
+  return { label: e.event_type, color: "gray" };
+};
+
+const CertificateLineageDialog = ({ open, onClose, lineage }) => {
+  const events = useMemo(() => {
+    if (!lineage?.timeline) return [];
+    const sorted = [...lineage.timeline].sort(
+      (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
+    );
+    return sorted.map((e) => {
+      const meta = classify(e);
+      return {
+        key: `${e.event_type}:${e.entity_id}:${e.timestamp}`,
+        color: meta.color,
+        children: (
+          <div>
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              <Text strong>{meta.label}</Text>
+              <Text type="secondary">
+                {new Date(e.timestamp).toLocaleString()}
+              </Text>
+            </div>
+            <div style={{ marginTop: 4 }}>
+              {normalizeDiffs(e.diffs).map((d) => (
+                <div key={d.field} style={{ fontSize: 12 }}>
+                  <Text type="secondary">{d.field}: </Text>
+                  <Tag color="default">{String(d.before)}</Tag>
+                  <span style={{ margin: "0 4px" }}>→</span>
+                  <Tag color="processing">{String(d.after)}</Tag>
+                </div>
+              ))}
+            </div>
+          </div>
+        ),
+      };
+    });
+  }, [lineage]);
+
+  if (!lineage) return null;
+
+  return (
+    <Modal
+      title="Certificate Lineage"
+      open={open}
+      onCancel={onClose}
+      width={720}
+      footer={null}
+    >
+      <div style={{ padding: 16 }}>
+        <div style={{ marginBottom: 12 }}>
+          <Text type="secondary" style={{ marginRight: 16 }}>
+            Bundle ID:
+          </Text>
+          <Text strong>{lineage.bundle_id}</Text>
+        </div>
+        <div style={{ marginBottom: 12 }}>
+          <Text type="secondary" style={{ marginRight: 16 }}>
+            Issuance ID:
+          </Text>
+          <Text strong>{lineage.issuance_id}</Text>
+        </div>
+        <Timeline items={events} />
+      </div>
+    </Modal>
+  );
+};
+
+export default CertificateLineageDialog;

--- a/frontend/src/components/Certificate/CertificateLineageDialog.js
+++ b/frontend/src/components/Certificate/CertificateLineageDialog.js
@@ -1,7 +1,19 @@
 import React, { useMemo } from "react";
-import { Modal, Timeline, Typography, Tag } from "antd";
+import { Modal, Timeline, Typography, Tag, Button } from "antd";
 
 const { Text } = Typography;
+
+const normalizeDiffs = (diffs) => {
+  if (Array.isArray(diffs)) return diffs;
+  if (diffs && typeof diffs === "object") {
+    return Object.entries(diffs).map(([field, v]) => ({
+      field,
+      before: v?.before,
+      after: v?.after,
+    }));
+  }
+  return [];
+};
 
 const statusColor = (status) => {
   switch (status) {
@@ -24,18 +36,6 @@ const statusColor = (status) => {
     default:
       return "blue";
   }
-};
-
-const normalizeDiffs = (diffs) => {
-    if (Array.isArray(diffs)) return diffs;
-    if (diffs && typeof diffs == "object") {
-        return Object.entries(diffs).map(([field, v]) => ({
-            field,
-            before: v?.before,
-            after: v?.after,
-        }));
-    }
-    return [];
 };
 
 const classify = (e) => {
@@ -110,6 +110,59 @@ const CertificateLineageDialog = ({ open, onClose, lineage }) => {
 
   if (!lineage) return null;
 
+  // Support both raw lineage and formatted timeline payloads
+  const bundleId = lineage.bundle_id ?? lineage.bundle?.bundle_id;
+  const issuanceId = lineage.issuance_id ?? lineage.bundle?.issuance_id;
+
+  const buildLineageExport = (lineageObj) => {
+    const sorted = [...(lineageObj?.timeline || [])].sort(
+      (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
+    );
+    const eventsExport = sorted.map((e, idx) => ({
+      index: idx,
+      timestamp: e.timestamp,
+      event_type: e.event_type,
+      entity_id: e.entity_id,
+      parent_entity_id: e.parent_entity_id ?? null,
+      label: classify(e).label,
+      kind: classify(e).kind || "update",
+      diffs: Array.isArray(e.diffs) ? e.diffs : normalizeDiffs(e.diffs),
+      attributes_before: e.attributes_before || {},
+      attributes_after: e.attributes_after || {},
+    }));
+    return {
+      version: "1.0.0",
+      exported_at: new Date().toISOString(),
+      bundle: {
+        bundle_id: bundleId,
+        issuance_id: issuanceId,
+        lineage_path: lineageObj.lineage_path || [],
+        created_at: lineageObj.created_at || null,
+        last_updated_at: lineageObj.last_updated_at || null,
+        current_state: lineageObj.current_state || {},
+      },
+      events: eventsExport,
+      graph: {
+        nodes: Array.from(
+          new Set(eventsExport.flatMap((e) => [e.entity_id, e.parent_entity_id].filter(Boolean)))
+        ).map((id) => ({ id })),
+        edges: eventsExport
+          .filter((e) => e.parent_entity_id != null)
+          .map((e) => ({ from: e.parent_entity_id, to: e.entity_id, type: "split" })),
+      },
+    };
+  };
+
+  const downloadJSON = (obj, filename) => {
+    const blob = new Blob([JSON.stringify(obj, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <Modal
       title="Certificate Lineage"
@@ -123,15 +176,28 @@ const CertificateLineageDialog = ({ open, onClose, lineage }) => {
           <Text type="secondary" style={{ marginRight: 16 }}>
             Bundle ID:
           </Text>
-          <Text strong>{lineage.bundle_id}</Text>
+          <Text strong>{bundleId}</Text>
         </div>
         <div style={{ marginBottom: 12 }}>
           <Text type="secondary" style={{ marginRight: 16 }}>
             Issuance ID:
           </Text>
-          <Text strong>{lineage.issuance_id}</Text>
+        <Text strong>{issuanceId}</Text>
         </div>
         <Timeline items={events} />
+      </div>
+      <div style={{ padding: 16 }}>
+        <Button
+          type="primary"
+          onClick={() =>
+            downloadJSON(
+              buildLineageExport(lineage),
+              `lineage_${issuanceId || bundleId || "bundle"}.json`
+            )
+          }
+        >
+          Download Lineage
+        </Button>
       </div>
     </Modal>
   );

--- a/frontend/src/components/Certificate/CertificateLineageDialog.js
+++ b/frontend/src/components/Certificate/CertificateLineageDialog.js
@@ -46,10 +46,17 @@ const classify = (e) => {
 
   if (e.event_type === "CREATE") {
     if (e.parent_entity_id != null) {
-      return {
-        label: `Split: child #${e.entity_id} from #${e.parent_entity_id}`,
-        color: "purple",
-      };
+      if (e.parent_entity_id.startsWith("S-")) {
+        return {
+          label: `Time-shifted: child #${e.entity_id} from #${e.parent_entity_id}`,
+          color: "blue",
+        };
+      } else {
+        return {
+          label: `Split: child #${e.entity_id} from #${e.parent_entity_id}`,
+          color: "purple",
+        };
+      }
     }
     return { label: `Bundle created #${e.entity_id}`, color: "green" };
   }
@@ -148,7 +155,11 @@ const CertificateLineageDialog = ({ open, onClose, lineage }) => {
         ).map((id) => ({ id })),
         edges: eventsExport
           .filter((e) => e.parent_entity_id != null)
-          .map((e) => ({ from: e.parent_entity_id, to: e.entity_id, type: "split" })),
+            .map((e) => ({
+            from: e.parent_entity_id,
+            to: e.entity_id,
+            type: e.parent_entity_id.startsWith("S-") ? "time_shift" : "split",
+          })),
       },
     };
   };

--- a/frontend/src/components/Certificate/index.js
+++ b/frontend/src/components/Certificate/index.js
@@ -25,11 +25,13 @@ import {
   getCertificateDetails,
   downloadCertificates,
   downloadSelectedCertificate,
+  getCertificateLineage,
 } from "../../store/certificate/certificateThunk";
 
 import CertificateActionDialog from "./CertificateActionDialog";
 import CertificateDetailDialog from "./CertificateDetailDialog";
 import CertificateImportDialog from "./CertificateImportDialog";
+import CertificateLineageDialog from "./CertificateLineageDialog";
 import Summary from "./Summary";
 
 import StatusTag from "../Common/StatusTag";
@@ -53,6 +55,9 @@ const Certificate = () => {
 
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [selectedCertificateData, setSelectedCertificateData] = useState(null);
+
+  const [isLineageModalOpen, setIsLineageModalOpen] = useState(false);
+  const [selectedLineageData, setSelectedLineageData] = useState(null);
 
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
   const [selectedRecords, setSelectedRecords] = useState([]);
@@ -88,6 +93,8 @@ const Certificate = () => {
     device_id: null,
     energy_source: null,
     certificate_bundle_status: "active",
+    certificate_period_start: null,
+    certificate_period_end: null,
   };
 
   const [filters, setFilters] = useState(defaultFilters);
@@ -186,6 +193,18 @@ const Certificate = () => {
     }
   };
 
+  const handleGetCertificateLineage = async (certificateId) => {
+    try {
+      const response = await dispatch(
+        getCertificateLineage(certificateId)
+      ).unwrap();
+      setSelectedLineageData(response);
+      setIsLineageModalOpen(true);
+    } catch (error) {
+      message.error(error?.message || "Failed to fetch certificate lineage");
+    }
+  };
+
   const handleClearFilter = async () => {
     setFilters(defaultFilters);
     fetchCertificatesData(defaultFilters);
@@ -203,6 +222,14 @@ const Certificate = () => {
   };
 
   const handleDateChange = (dates) => {
+    if (!dates || dates.length === 0) {
+      setFilters((prev) => ({
+        ...prev,
+        certificate_period_start: null,
+        certificate_period_end: null,
+      }));
+      return;
+    }
     setFilters((prev) => ({
       ...prev,
       certificate_period_start: dates[0],
@@ -384,11 +411,14 @@ const Certificate = () => {
     </Select>,
     /* Date range Filter */
     <RangePicker
-      value={[filters.certificate_period_start, filters.certificate_period_end]}
+      value={[
+        filters.certificate_period_start || null,
+        filters.certificate_period_end || null,
+      ]}
       onChange={(dates) => handleDateChange(dates)}
-      allowClear={true} // Change to true to allow clearing
+      allowClear={true}
       format="YYYY-MM-DD"
-      placeholder={["Start Date", "End Date"]} // Add placeholder text
+      placeholder={["Start Date", "End Date"]}
     />,
     <Select
       // mode="multiple"
@@ -500,13 +530,19 @@ const Certificate = () => {
       title: "",
       render: (_, record) => {
         return (
-          <Button
+          <><Button
             style={{ color: "#043DDC", fontWeight: "600" }}
             type="link"
             onClick={() => handleGetCertificateDetail(record.id)}
           >
             Details
-          </Button>
+          </Button><Button
+            style={{ color: "#043DDC", fontWeight: "600" }}
+            type="link"
+            onClick={() => handleGetCertificateLineage(record.id)}
+          >
+              Lineage
+            </Button></>
         );
       },
     },
@@ -559,6 +595,11 @@ const Certificate = () => {
         open={isDetailModalOpen}
         onClose={() => setIsDetailModalOpen(false)}
         certificateData={selectedCertificateData}
+      />
+      <CertificateLineageDialog
+        open={isLineageModalOpen}
+        onClose={() => setIsLineageModalOpen(false)}
+        lineage={selectedLineageData}
       />
     </>
   );

--- a/frontend/src/components/Common/SideMenu.js
+++ b/frontend/src/components/Common/SideMenu.js
@@ -15,6 +15,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import sampleAvatar from "../../assets/images/gcos_avatar.png";
 import Cookies from "js-cookie";
 import { useUser } from "../../context/UserContext";
+import { useAccount } from "../../context/AccountContext";
 
 const { Text } = Typography;
 
@@ -25,6 +26,7 @@ const SideMenu = () => {
   const [isAccountPickerAllowed, setIsAccountPickerAllowed] = useState(false);
   const [isShowDevices, setIsShowDevices] = useState(false);
   const { userData } = useUser();
+  const { currentAccount } = useAccount();
 
   useEffect(() => {
     console.log(userData);
@@ -144,6 +146,24 @@ const SideMenu = () => {
         }}
       >
         Granular <span style={{ color: "#0057FF" }}>CertOS</span>
+      </div>
+      <div style={{ padding: "0 16px", marginBottom: "16px" }}>
+        <div
+          style={{
+            background: "#F5F7FF",
+            border: "1px solid #E0E7FF",
+            borderRadius: "8px",
+            padding: "8px 12px",
+            marginBottom: "8px",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <Text style={{ color: "#043DDC", fontWeight: 600 }}>
+            {currentAccount?.detail?.account_name || "—"}
+          </Text>
+        </div>
       </div>
       <Menu
         mode="vertical"

--- a/frontend/src/components/Device/DeviceUploadDataForm.js
+++ b/frontend/src/components/Device/DeviceUploadDataForm.js
@@ -60,8 +60,7 @@ const DeviceUploadDialog = forwardRef((props, ref) => {
     try {
       const formData = new FormData();
       formData.append("file", fileList[0]);
-      formData.append("deviceID", deviceInfo?.deviceID);
-      formData.append("accountID", deviceInfo?.accountID);
+      formData.append("device_id", deviceInfo?.deviceID);
 
       const response = await submitMeterReadingsAPI(formData);
 

--- a/frontend/src/store/certificate/certificateThunk.js
+++ b/frontend/src/store/certificate/certificateThunk.js
@@ -4,6 +4,7 @@ import {
   transferCertificateAPI,
   cancelCertificateAPI,
   getCertificateDetailsAPI,
+  getCertificateLineageAPI,
   downloadCertificatesAPI,
   downloadSelectedCertificateAPI,
 } from "../../api/certificateAPI";
@@ -93,6 +94,20 @@ export const downloadSelectedCertificate = createAsyncThunk(
     } catch (error) {
       return rejectWithValue(
         error.response?.data || "Failed to download selected certificate details"
+      );
+    }
+  }
+);
+
+export const getCertificateLineage = createAsyncThunk(
+  "certificates/getLineage",
+  async (certificateId, { rejectWithValue }) => {
+    try {
+      const response = await getCertificateLineageAPI(certificateId);
+      return response?.data;
+    } catch (error) {
+      return rejectWithValue(
+        error.response?.data || "Failed to fetch certificate lineage"
       );
     }
   }

--- a/gc_registry/certificate/routes.py
+++ b/gc_registry/certificate/routes.py
@@ -603,7 +603,7 @@ def certificate_bundle_reserve(
 
 
 @router.get(
-    "/lineage/{id}",
+    "/{id}/lineage",
     status_code=200,
 )
 def get_certificate_bundle_lineage(

--- a/gc_registry/certificate/routes.py
+++ b/gc_registry/certificate/routes.py
@@ -15,7 +15,6 @@ from gc_registry.certificate.models import (
 from gc_registry.certificate.schemas import (
     GranularCertificateActionRead,
     GranularCertificateBundleBase,
-    GranularCertificateBundleLineage,
     GranularCertificateBundleRead,
     GranularCertificateBundleReadFull,
     GranularCertificateCancel,
@@ -27,7 +26,6 @@ from gc_registry.certificate.schemas import (
     IssuanceMetaDataBase,
 )
 from gc_registry.core.database import db, events
-from gc_registry.core.database.events import retrieve_all_events_for_entity
 from gc_registry.core.models.base import CertificateActionType, UserRoles
 from gc_registry.core.services import create_bundle_hash
 from gc_registry.device.models import Device
@@ -627,7 +625,7 @@ def get_certificate_bundle_lineage(
     )
 
     lineage = services.get_certificate_bundle_lineage(
-        current_certificate_bundle, read_session, esdb_client
+        current_certificate_bundle, esdb_client
     )
 
     if format == "timeline":

--- a/gc_registry/certificate/routes.py
+++ b/gc_registry/certificate/routes.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from esdbclient import EventStoreDBClient
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
 from sqlmodel import Session
 
@@ -15,6 +15,7 @@ from gc_registry.certificate.models import (
 from gc_registry.certificate.schemas import (
     GranularCertificateActionRead,
     GranularCertificateBundleBase,
+    GranularCertificateBundleLineage,
     GranularCertificateBundleRead,
     GranularCertificateBundleReadFull,
     GranularCertificateCancel,
@@ -26,6 +27,7 @@ from gc_registry.certificate.schemas import (
     IssuanceMetaDataBase,
 )
 from gc_registry.core.database import db, events
+from gc_registry.core.database.events import retrieve_all_events_for_entity
 from gc_registry.core.models.base import CertificateActionType, UserRoles
 from gc_registry.core.services import create_bundle_hash
 from gc_registry.device.models import Device
@@ -600,3 +602,40 @@ def certificate_bundle_reserve(
     )
 
     return db_certificate_action
+
+
+@router.get(
+    "/lineage/{id}",
+    status_code=200,
+)
+def get_certificate_bundle_lineage(
+    id: int,
+    format: str = Query(default="timeline"),
+    current_user: User = Depends(get_current_user),
+    read_session: Session = Depends(db.get_read_session),
+    esdb_client: EventStoreDBClient = Depends(events.get_esdb_client),
+):
+    """Get the lineage of a given certificate bundle by ID."""
+    validate_user_role(current_user, required_role=UserRoles.AUDIT_USER)
+
+    # Validate access against the bundle's account
+    current_certificate_bundle = GranularCertificateBundle.by_id(id, read_session)
+    if not current_certificate_bundle:
+        raise HTTPException(status_code=404, detail="Certificate bundle not found")
+    validate_user_access(
+        current_user, current_certificate_bundle.account_id, read_session
+    )
+
+    lineage = services.get_certificate_bundle_lineage(
+        current_certificate_bundle, read_session, esdb_client
+    )
+
+    if format == "timeline":
+        return services.format_lineage_for_timeline(lineage)
+    elif format == "raw":
+        return lineage
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid format: {format}. Valid formats are: timeline, raw",
+        )

--- a/gc_registry/certificate/schemas.py
+++ b/gc_registry/certificate/schemas.py
@@ -1,6 +1,7 @@
 import datetime
 from enum import Enum
 from functools import partial
+from typing import Any
 
 from fastapi import HTTPException
 from pydantic import BaseModel, model_validator
@@ -12,6 +13,7 @@ from gc_registry.core.models.base import (
     CertificateStatus,
     EnergyCarrierType,
     EnergySourceType,
+    EventTypes,
 )
 
 utc_datetime_now = partial(datetime.datetime.now, datetime.timezone.utc)
@@ -748,3 +750,89 @@ class GranularCertificateImportResponse(BaseModel):
         default=None,
         description="The result of the action that was performed, including the action type, outcome, and any details.",
     )
+
+
+class AttributeDiff(BaseModel):
+    """Field-level change in a GC bundle event."""
+
+    field: str
+    before: Any | None = None
+    after: Any | None = None
+
+
+class LineageTimelineEntry(BaseModel):
+    """Normalized view of a single event affecting a GC bundle."""
+
+    event_type: EventTypes
+    timestamp: datetime.datetime
+    entity_id: int | str
+    parent_entity_id: int | str | None = None
+    attributes_before: dict | None = None
+    attributes_after: dict | None = None
+    diffs: list[AttributeDiff] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def compute_diffs(cls, values):
+        before = values.attributes_before or {}
+        after = values.attributes_after or {}
+        fields = set(mutable_gc_attributes) | set(before.keys()) | set(after.keys())
+        diffs: list[AttributeDiff] = []
+        for f in fields:
+            b = before.get(f)
+            a = after.get(f)
+            if b != a:
+                diffs.append(AttributeDiff(field=f, before=b, after=a))
+        values.diffs = diffs
+        return values
+
+
+class GranularCertificateBundleLineage(BaseModel):
+    """Lineage of a GC bundle from creation through updates/deletes.
+    issuance_id remains constant across splits; ids change per child bundle.
+    """
+
+    bundle_id: int
+    entity_name: str = Field(default="GranularCertificateBundle")
+    issuance_id: str | None = None
+    lineage_path: list[int | str] = Field(
+        default_factory=list,
+        description="Parent-to-child path of entity IDs leading to this bundle.",
+    )
+    timeline: list[LineageTimelineEntry] = Field(default_factory=list)
+    created_at: datetime.datetime | None = None
+    last_updated_at: datetime.datetime | None = None
+    current_state: dict | None = Field(
+        default=None,
+        description="Snapshot of latest known attributes for this bundle (this bundle_id only).",
+    )
+
+    @model_validator(mode="after")
+    def derive_metadata(cls, values):
+        events = sorted(values.timeline, key=lambda e: e.timestamp)
+        if not events:
+            return values
+
+        # Timestamps
+        values.created_at = events[0].timestamp
+        values.last_updated_at = events[-1].timestamp
+
+        # Build lineage_path from parent links
+        parent_of: dict[int | str, int | str | None] = {
+            e.entity_id: e.parent_entity_id for e in events
+        }
+        path: list[int | str] = []
+        curr: int | str | None = values.bundle_id
+        while curr is not None:
+            path.append(curr)
+            curr = parent_of.get(curr)
+        values.lineage_path = list(reversed(path))
+
+        # Compute current_state using only this bundle_id’s events
+        state: dict = {}
+        for e in events:
+            if e.entity_id == values.bundle_id and e.attributes_after:
+                state.update(e.attributes_after)
+        if state:
+            values.current_state = state
+
+        return values

--- a/gc_registry/certificate/services.py
+++ b/gc_registry/certificate/services.py
@@ -1468,8 +1468,8 @@ def format_lineage_for_timeline(
                 if isinstance(
                     entry.parent_entity_id, str
                 ) and entry.parent_entity_id.startswith("S-"):
-                    entry.parent_entity_id = entry.parent_entity_id.split("-")[1]
-                    label = f"Time-shifted: child #{entry.entity_id:,} from #{entry.parent_entity_id:,} "
+                    entry.parent_entity_id = int(entry.parent_entity_id.split("-")[1])
+                    label = f"Time-shifted: #{entry.entity_id:,} from #{entry.parent_entity_id:,} "
                     icon = "time_shift"
                     color = "blue"
                     kind = "time_shifted"

--- a/gc_registry/certificate/services.py
+++ b/gc_registry/certificate/services.py
@@ -24,6 +24,7 @@ from gc_registry.certificate.schemas import (
     GranularCertificateActionRead,
     GranularCertificateBundleBase,
     GranularCertificateBundleCreate,
+    GranularCertificateBundleLineage,
     GranularCertificateBundleRead,
     GranularCertificateCancel,
     GranularCertificateCancelStorage,
@@ -34,13 +35,14 @@ from gc_registry.certificate.schemas import (
     GranularCertificateTransfer,
     GranularCertificateWithdraw,
     IssuanceMetaDataBase,
+    LineageTimelineEntry,
 )
 from gc_registry.certificate.validation import (
     validate_granular_certificate_bundle,
     validate_imported_granular_certificate_bundle,
 )
 from gc_registry.core.database import cqrs, db, events
-from gc_registry.core.models.base import CertificateActionType
+from gc_registry.core.models.base import CertificateActionType, EventTypes
 from gc_registry.core.services import create_bundle_hash
 from gc_registry.device.meter_data.abstract_meter_client import AbstractMeterDataClient
 from gc_registry.device.models import Device
@@ -145,6 +147,9 @@ def split_certificate_bundle(
         granular_certificate_bundle_child_2, granular_certificate_bundle.hash
     )
 
+    # Retain the parent bundle ID for lineage tracking
+    parent_bundle_id = granular_certificate_bundle.id
+
     # Mark the parent bundle as withdrawn and apply soft delete
     granular_certificate_bundle.certificate_bundle_status = (
         CertificateStatus.BUNDLE_SPLIT
@@ -153,10 +158,18 @@ def split_certificate_bundle(
 
     # Write the child bundles to the database
     db_granular_certificate_bundle_child_1 = GranularCertificateBundle.create(
-        granular_certificate_bundle_child_1, write_session, read_session, esdb_client
+        granular_certificate_bundle_child_1,
+        write_session,
+        read_session,
+        esdb_client,
+        parent_entity_id=parent_bundle_id,
     )
     db_granular_certificate_bundle_child_2 = GranularCertificateBundle.create(
-        granular_certificate_bundle_child_2, write_session, read_session, esdb_client
+        granular_certificate_bundle_child_2,
+        write_session,
+        read_session,
+        esdb_client,
+        parent_entity_id=parent_bundle_id,
     )
 
     return db_granular_certificate_bundle_child_1[
@@ -1381,3 +1394,180 @@ def import_gc_bundles(
     ]
 
     return gc_bundles_cast
+
+
+def get_certificate_bundle_lineage(
+    current_bundle: GranularCertificateBundle,
+    read_session: Session,
+    esdb_client: EventStoreDBClient,
+) -> GranularCertificateBundleLineage:
+    """Get the lineage of a given certificate bundle by ID."""
+
+    event_stream = events.retrieve_all_events_for_entity(
+        entity_id=current_bundle.id,
+        entity_name="GranularCertificateBundle",
+        stream_name="events",
+        esdb_client=esdb_client,
+    )
+
+    timeline = [
+        LineageTimelineEntry(
+            event_type=e["type"],
+            timestamp=e["timestamp"],
+            entity_id=e["entity_id"],
+            parent_entity_id=e.get("parent_entity_id"),
+            attributes_before=e.get("attributes_before"),
+            attributes_after=e.get("attributes_after"),
+        )
+        for e in event_stream
+    ]
+
+    lineage = GranularCertificateBundleLineage(
+        bundle_id=current_bundle.id,
+        issuance_id=current_bundle.issuance_id,
+        timeline=timeline,
+        current_state=current_bundle.model_dump(),
+    )
+
+    return lineage
+
+
+def format_lineage_for_timeline(
+    lineage: GranularCertificateBundleLineage,
+) -> dict[str, Any]:
+    """Convert a GranularCertificateBundleLineage into a user-friendly timeline JSON.
+
+    The output is suitable both for API responses (easy to read JSON) and
+    frontend timeline rendering (label/icon/color per event).
+
+    Args:
+        lineage: The lineage model returned from get_certificate_bundle_lineage.
+
+    Returns:
+        dict: A structured representation with header info and timeline events.
+    """
+
+    def _iso(ts: datetime.datetime | str) -> str:
+        if isinstance(ts, str):
+            return ts
+        if ts.tzinfo is None:
+            return ts.isoformat() + "Z"
+        return ts.astimezone(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _diffs_to_dict(diffs: list) -> dict[str, Any]:
+        return {d.field: {"before": d.before, "after": d.after} for d in diffs}
+
+    def _classify_event(entry: LineageTimelineEntry) -> dict[str, Any]:
+        label = f"{entry.event_type.title()}"
+        icon = "update"
+        color = "gray"
+        kind = "update"
+        details: dict[str, Any] = {}
+
+        if entry.event_type == EventTypes.CREATE:
+            if entry.parent_entity_id is not None:
+                label = f"Split: child #{entry.entity_id:,} from #{entry.parent_entity_id:,} "
+                icon = "split"
+                color = "purple"
+                kind = "split_child_created"
+            else:
+                label = f"Bundle created #{entry.entity_id}"
+                icon = "create"
+                color = "green"
+                kind = "created"
+
+        # Soft deletes on bundles are used to indicate when a parent bundle is split into child bundles
+        elif entry.event_type == EventTypes.DELETE:
+            label = f"Bundle #{entry.entity_id:,} deleted"
+            icon = "delete"
+            color = "red"
+            kind = "deleted"
+
+        elif entry.event_type == EventTypes.UPDATE:
+            diffs = _diffs_to_dict(entry.diffs)
+
+            if "account_id" in diffs:
+                b = diffs["account_id"]["before"]
+                a = diffs["account_id"]["after"]
+                label = f"Transferred: account {b} → {a}"
+                icon = "transfer"
+                color = "blue"
+                kind = "transfer"
+                details["from_account_id"] = b
+                details["to_account_id"] = a
+
+            elif "certificate_bundle_status" in diffs:
+                new_status = diffs["certificate_bundle_status"]["after"]
+                label = f"Status: {new_status}"
+                kind = "status_change"
+
+                # Map statuses to icons/colors
+                status_icon_map = {
+                    CertificateStatus.CANCELLED: ("cancel", "red"),
+                    CertificateStatus.CANCELLED_FOR_STORAGE: ("storage", "orange"),
+                    CertificateStatus.CLAIMED: ("claim", "green"),
+                    CertificateStatus.RESERVED: ("reserve", "yellow"),
+                    CertificateStatus.LOCKED: ("lock", "gray"),
+                    CertificateStatus.WITHDRAWN: ("withdraw", "gray"),
+                    CertificateStatus.ACTIVE: ("activate", "green"),
+                    CertificateStatus.BUNDLE_SPLIT: ("split", "purple"),
+                    CertificateStatus.EXPIRED: ("expired", "gray"),
+                }
+                icon, color = status_icon_map.get(new_status, ("update", "gray"))
+
+                # Optional beneficiary present on cancellation/claim
+                if "beneficiary" in diffs:
+                    details["beneficiary"] = diffs["beneficiary"]["after"]
+
+            else:
+                # General update fallback
+                label = "Bundle updated"
+                icon = "update"
+                color = "gray"
+                kind = "update"
+
+        return {
+            "id": f"{entry.event_type}:{entry.entity_id}:{_iso(entry.timestamp)}",
+            "timestamp": _iso(entry.timestamp),
+            "entity_id": entry.entity_id,
+            "parent_entity_id": entry.parent_entity_id,
+            "event_type": entry.event_type,
+            "label": label,
+            "icon": icon,
+            "color": color,
+            "kind": kind,
+            "diffs": _diffs_to_dict(entry.diffs),
+            "raw_before": entry.attributes_before or {},
+            "raw_after": entry.attributes_after or {},
+            "details": details,
+        }
+
+    entries = sorted(lineage.timeline, key=lambda e: e.timestamp)
+
+    formatted_events = [_classify_event(e) for e in entries]
+
+    result = {
+        "bundle": {
+            "bundle_id": lineage.bundle_id,
+            "issuance_id": lineage.issuance_id,
+            "lineage_path": lineage.lineage_path,
+            "created_at": _iso(lineage.created_at) if lineage.created_at else None,
+            "last_updated_at": _iso(lineage.last_updated_at)
+            if lineage.last_updated_at
+            else None,
+            "current_state": lineage.current_state or {},
+        },
+        "timeline": formatted_events,
+        "summary": {
+            "event_count": len(formatted_events),
+            "transfers": sum(1 for e in formatted_events if e["kind"] == "transfer"),
+            "status_changes": sum(
+                1 for e in formatted_events if e["kind"] == "status_change"
+            ),
+            "splits": sum(
+                1 for e in formatted_events if e["kind"] == "split_child_created"
+            ),
+            "deleted": any(e["kind"] == "deleted" for e in formatted_events),
+        },
+    }
+    return result

--- a/gc_registry/certificate/services.py
+++ b/gc_registry/certificate/services.py
@@ -1465,10 +1465,19 @@ def format_lineage_for_timeline(
 
         if entry.event_type == EventTypes.CREATE:
             if entry.parent_entity_id is not None:
-                label = f"Split: child #{entry.entity_id:,} from #{entry.parent_entity_id:,} "
-                icon = "split"
-                color = "purple"
-                kind = "split_child_created"
+                if isinstance(
+                    entry.parent_entity_id, str
+                ) and entry.parent_entity_id.startswith("S-"):
+                    entry.parent_entity_id = entry.parent_entity_id.split("-")[1]
+                    label = f"Time-shifted: child #{entry.entity_id:,} from #{entry.parent_entity_id:,} "
+                    icon = "time_shift"
+                    color = "blue"
+                    kind = "time_shifted"
+                else:
+                    label = f"Split: child #{entry.entity_id:,} from #{entry.parent_entity_id:,} "
+                    icon = "split"
+                    color = "purple"
+                    kind = "split_child_created"
             else:
                 label = f"Bundle created #{entry.entity_id}"
                 icon = "create"

--- a/gc_registry/certificate/services.py
+++ b/gc_registry/certificate/services.py
@@ -1398,13 +1398,12 @@ def import_gc_bundles(
 
 def get_certificate_bundle_lineage(
     current_bundle: GranularCertificateBundle,
-    read_session: Session,
     esdb_client: EventStoreDBClient,
 ) -> GranularCertificateBundleLineage:
     """Get the lineage of a given certificate bundle by ID."""
 
     event_stream = events.retrieve_all_events_for_entity(
-        entity_id=current_bundle.id,
+        entity_id=current_bundle.id,  # type: ignore
         entity_name="GranularCertificateBundle",
         stream_name="events",
         esdb_client=esdb_client,
@@ -1423,7 +1422,7 @@ def get_certificate_bundle_lineage(
     ]
 
     lineage = GranularCertificateBundleLineage(
-        bundle_id=current_bundle.id,
+        bundle_id=current_bundle.id,  # type: ignore
         issuance_id=current_bundle.issuance_id,
         timeline=timeline,
         current_state=current_bundle.model_dump(),

--- a/gc_registry/core/database/cqrs.py
+++ b/gc_registry/core/database/cqrs.py
@@ -17,6 +17,7 @@ def write_to_database(
     write_session: Session,
     read_session: Session,
     esdb_client: EventStoreDBClient,
+    **kwargs,
 ) -> list[SQLModel]:
     """Write the provided entities to the read and write databases, saving an
     Event entry for each entity."""
@@ -61,6 +62,7 @@ def write_to_database(
             entity_names=[entity.__class__.__name__ for entity in entities],
             event_type=EventTypes.CREATE,
             esdb_client=esdb_client,
+            **kwargs,
         )
 
     write_session.commit()

--- a/gc_registry/core/database/events.py
+++ b/gc_registry/core/database/events.py
@@ -127,9 +127,13 @@ def retrieve_all_events_for_entity(
             entity_events.append(event_data)
 
             if event_data.get("parent_entity_id") is not None:
+                if event_data["parent_entity_id"].startswith("S-"):
+                    parent_entity_id = int(event_data["parent_entity_id"].split("-")[1])
+                else:
+                    parent_entity_id = int(event_data["parent_entity_id"])
                 entity_events.extend(
                     retrieve_all_events_for_entity(
-                        entity_id=event_data["parent_entity_id"],
+                        entity_id=parent_entity_id,
                         entity_name=entity_name,
                         stream_name=stream_name,
                         esdb_client=esdb_client,

--- a/gc_registry/core/database/events.py
+++ b/gc_registry/core/database/events.py
@@ -31,6 +31,7 @@ def create_event(
     attributes_before: dict | None = None,
     attributes_after: dict | None = None,
     esdb_client: EventStoreDBClient = Depends(get_esdb_client),
+    **kwargs,
 ):
     """Create a single event and append it to the ESDB events stream."""
 
@@ -39,6 +40,7 @@ def create_event(
         entity_name=entity_name,
         attributes_before=attributes_before,
         attributes_after=attributes_after,
+        parent_entity_id=kwargs.get("parent_entity_id"),
     )
 
     esdb_event = NewEvent(
@@ -61,6 +63,7 @@ def batch_create_events(
     attributes_before: list[dict | None] | None = None,
     attributes_after: list[dict | None] | None = None,
     esdb_client: EventStoreDBClient = Depends(get_esdb_client),
+    **kwargs,
 ):
     """Create a batch of events and append them to the ESDB events stream.
 
@@ -76,6 +79,7 @@ def batch_create_events(
         Event(
             entity_id=entity_id,
             entity_name=entity_name,
+            parent_entity_id=kwargs.get("parent_entity_id"),
             attributes_before=attributes_before,
             attributes_after=attributes_after,
         )
@@ -108,7 +112,7 @@ def retrieve_all_events_for_entity(
 ):
     """Retrieve all events for an entity from the ESDB events stream."""
     try:
-        event_stream = esdb_client.read_stream(stream_name=stream_name)
+        event_stream = esdb_client.get_stream(stream_name=stream_name)
     except NotFound:
         raise ValueError(f"Stream {stream_name} not found")
 
@@ -121,6 +125,16 @@ def retrieve_all_events_for_entity(
         ):
             event_data["type"] = event.type
             entity_events.append(event_data)
+
+            if event_data.get("parent_entity_id") is not None:
+                entity_events.extend(
+                    retrieve_all_events_for_entity(
+                        entity_id=event_data["parent_entity_id"],
+                        entity_name=entity_name,
+                        stream_name=stream_name,
+                        esdb_client=esdb_client,
+                    )
+                )
 
     return entity_events
 

--- a/gc_registry/core/database/events.py
+++ b/gc_registry/core/database/events.py
@@ -1,7 +1,9 @@
+import json
 import uuid
 from typing import Generator
 
 from esdbclient import EventStoreDBClient, NewEvent, StreamState
+from esdbclient.exceptions import NotFound
 from fastapi import Depends
 
 from gc_registry.core.models.base import Event, EventTypes
@@ -96,6 +98,31 @@ def batch_create_events(
         current_version=StreamState.ANY,
         events=esdb_events,
     )
+
+
+def retrieve_all_events_for_entity(
+    entity_id: int,
+    entity_name: str,
+    stream_name: str = "events",
+    esdb_client: EventStoreDBClient = Depends(get_esdb_client),
+):
+    """Retrieve all events for an entity from the ESDB events stream."""
+    try:
+        event_stream = esdb_client.read_stream(stream_name=stream_name)
+    except NotFound:
+        raise ValueError(f"Stream {stream_name} not found")
+
+    entity_events = []
+    for event in event_stream:
+        event_data = json.loads(event.data)
+        if (
+            event_data["entity_id"] == entity_id
+            and event_data["entity_name"] == entity_name
+        ):
+            event_data["type"] = event.type
+            entity_events.append(event_data)
+
+    return entity_events
 
 
 def reset_eventstore():

--- a/gc_registry/core/database/events.py
+++ b/gc_registry/core/database/events.py
@@ -127,7 +127,7 @@ def retrieve_all_events_for_entity(
             entity_events.append(event_data)
 
             if event_data.get("parent_entity_id") is not None:
-                if event_data["parent_entity_id"].startswith("S-"):
+                if str(event_data["parent_entity_id"]).startswith("S-"):
                     parent_entity_id = int(event_data["parent_entity_id"].split("-")[1])
                 else:
                     parent_entity_id = int(event_data["parent_entity_id"])

--- a/gc_registry/core/models/base.py
+++ b/gc_registry/core/models/base.py
@@ -91,10 +91,10 @@ class EventTypes(str, Enum):
 class Event(BaseModel):
     entity_id: int | uuid.UUID
     entity_name: str
-    parent_entity_id: int | uuid.UUID | None = Field(
+    parent_entity_id: int | uuid.UUID | str | None = Field(
         default=None,
         description="""If an entity is a child of another entity, this is the id of the parent entity, e.g. when a GC bundle is split into child bundles.
-        This is used to track the parent-child relationship between entities.""",
+        For time-shfting, the parent ID will a string prefixed with 'S-', e.g. 'S-123'""",
     )
     attributes_before: dict | None = Field(sa_column=Column(JSON))
     attributes_after: dict | None = Field(sa_column=Column(JSON))

--- a/gc_registry/core/models/base.py
+++ b/gc_registry/core/models/base.py
@@ -91,6 +91,11 @@ class EventTypes(str, Enum):
 class Event(BaseModel):
     entity_id: int | uuid.UUID
     entity_name: str
+    parent_entity_id: int | uuid.UUID | None = Field(
+        default=None,
+        description="""If an entity is a child of another entity, this is the id of the parent entity, e.g. when a GC bundle is split into child bundles.
+        This is used to track the parent-child relationship between entities.""",
+    )
     attributes_before: dict | None = Field(sa_column=Column(JSON))
     attributes_after: dict | None = Field(sa_column=Column(JSON))
     timestamp: datetime.datetime = Field(default_factory=utc_datetime_now)  # type: ignore

--- a/gc_registry/device/meter_data/manual_submission.py
+++ b/gc_registry/device/meter_data/manual_submission.py
@@ -86,6 +86,10 @@ class ManualSubmissionMeterClient(AbstractMeterDataClient):
         mapped_data: list = []
 
         for data in generation_data:
+            # Skip if the interval usage is less than or equal to 0
+            if data.interval_usage <= 0:
+                continue
+
             # Get existing "certificate_bundle_id_range_end" from the last item in mapped_data
             if mapped_data:
                 certificate_bundle_id_range_start = (

--- a/gc_registry/storage/services.py
+++ b/gc_registry/storage/services.py
@@ -255,7 +255,6 @@ def issue_sdgcs_against_allocated_records(
         if cancelled_gc_bundle:
             cancelled_gc_bundle_attrs = cancelled_gc_bundle.model_dump()
             for attr in [
-                "id",
                 "status",
                 "certificate_bundle_id_range_start",
                 "certificate_bundle_id_range_end",
@@ -296,10 +295,17 @@ def issue_sdgcs_against_allocated_records(
         certificate_bundle_id_range_start=max_certificate_bundle_id + 1,
     )
 
-    # Create the SDGCs
-    issued_sdgcs = GranularCertificateBundle.create(
-        mapped_sdgcs, write_session, read_session, esdb_client
-    )
+    # Create the SDGCs one by one to preserve parent ID for lineage
+    issued_sdgcs = []
+    for sdgc in mapped_sdgcs:
+        issued_sdgc = GranularCertificateBundle.create(
+            sdgc,
+            write_session,
+            read_session,
+            esdb_client,
+            parent_entity_id=f"S-{sdgc['cancelled_gc_id']}",
+        )
+        issued_sdgcs.append(issued_sdgc)
 
     if not issued_sdgcs:
         raise ValueError("No SDGCs were created. Please check the input data.")
@@ -385,6 +391,9 @@ def map_allocation_to_certificates(
         )
 
         transformed["hash"] = create_bundle_hash(transformed, nonce="")
+
+        # Temporarily add ID of cancelled GC for lineage tracking
+        transformed["cancelled_gc_id"] = sdgc["id"]
 
         mapped_data.append(transformed)
 

--- a/gc_registry/storage/services.py
+++ b/gc_registry/storage/services.py
@@ -241,6 +241,15 @@ def issue_sdgcs_against_allocated_records(
         allocated_storage_records, charge_records, cancelled_gc_bundles
     )
 
+    # Get SDRs for the specified allocation records
+    sdr_ids = [record.sdr_allocation_id for record in allocated_storage_records]
+    sdr_records = read_session.exec(
+        select(StorageRecord).where(StorageRecord.id.in_(sdr_ids))  # type: ignore[union-attr]
+    ).all()
+    sdr_records_df = pd.DataFrame(
+        [sdr_record.model_dump() for sdr_record in sdr_records]
+    )
+
     # Update a copy of the retrieved GC Bundles with the storage-specific attributes to pass through to the SDGC
     sdgcs_to_issue = []
     for allocated_storage_record in allocated_storage_records:
@@ -252,29 +261,45 @@ def issue_sdgcs_against_allocated_records(
             ),
             None,
         )
+
         if cancelled_gc_bundle:
             cancelled_gc_bundle_attrs = cancelled_gc_bundle.model_dump()
             for attr in [
-                "status",
+                "certificate_bundle_status",
                 "certificate_bundle_id_range_start",
                 "certificate_bundle_id_range_end",
+                "production_starting_interval",
+                "production_ending_interval",
+                "bundle_quantity",
             ]:
                 cancelled_gc_bundle_attrs.pop(attr)
             cancelled_gc_bundle_attrs["is_storage"] = True
-            cancelled_gc_bundle_attrs["allocated_storage_record_id"] = (
+            cancelled_gc_bundle_attrs["allocated_storage_record_id"] = int(
                 allocated_storage_record.id
             )
             cancelled_gc_bundle_attrs["storage_efficiency_factor"] = (
                 allocated_storage_record.storage_efficiency_factor
             )
+            cancelled_gc_bundle_attrs["bundle_quantity"] = (
+                allocated_storage_record.sdr_proportion
+                * (
+                    sdr_records_df.loc[
+                        sdr_records_df["id"]
+                        == allocated_storage_record.sdr_allocation_id
+                    ]["flow_energy"].iloc[0]
+                )
+            )
+            cancelled_gc_bundle_attrs["production_starting_interval"] = (
+                sdr_records_df.loc[
+                    sdr_records_df["id"] == allocated_storage_record.sdr_allocation_id
+                ]["flow_start_datetime"].iloc[0]
+            )
+            cancelled_gc_bundle_attrs["production_ending_interval"] = (
+                sdr_records_df.loc[
+                    sdr_records_df["id"] == allocated_storage_record.sdr_allocation_id
+                ]["flow_end_datetime"].iloc[0]
+            )
             sdgcs_to_issue.append(cancelled_gc_bundle_attrs)
-
-    # Get SDRs for the specified allocation records
-    sdr_ids = [record.sdr_allocation_id for record in allocated_storage_records]
-    sdr_records = read_session.exec(
-        select(StorageRecord).where(StorageRecord.id.in_(sdr_ids))  # type: ignore[union-attr]
-    ).all()
-    sdr_records_df = pd.DataFrame(sdr_records)
 
     # Get the max certificate bundle ID for the specified device
     if not device.id:
@@ -305,7 +330,7 @@ def issue_sdgcs_against_allocated_records(
             esdb_client,
             parent_entity_id=f"S-{sdgc['cancelled_gc_id']}",
         )
-        issued_sdgcs.append(issued_sdgc)
+        issued_sdgcs.extend(issued_sdgc)
 
     if not issued_sdgcs:
         raise ValueError("No SDGCs were created. Please check the input data.")
@@ -333,7 +358,7 @@ def issue_sdgcs_against_allocated_records(
     write_session.add_all(allocated_storage_records)
     write_session.commit()
 
-    return issued_sdgcs
+    return issued_sdgcs_cast
 
 
 def map_allocation_to_certificates(

--- a/gc_registry/storage/services.py
+++ b/gc_registry/storage/services.py
@@ -253,6 +253,11 @@ def issue_sdgcs_against_allocated_records(
     # Update a copy of the retrieved GC Bundles with the storage-specific attributes to pass through to the SDGC
     sdgcs_to_issue = []
     for allocated_storage_record in allocated_storage_records:
+        if allocated_storage_record.id is None:
+            raise ValueError(
+                f"Allocated storage record ID is None for allocated storage record {allocated_storage_record}"
+            )
+
         cancelled_gc_bundle = next(
             (
                 bundle
@@ -358,7 +363,7 @@ def issue_sdgcs_against_allocated_records(
     write_session.add_all(allocated_storage_records)
     write_session.commit()
 
-    return issued_sdgcs_cast
+    return issued_sdgcs
 
 
 def map_allocation_to_certificates(

--- a/gc_registry/utils.py
+++ b/gc_registry/utils.py
@@ -71,6 +71,7 @@ class ActiveRecord(SQLModel):
         write_session: Session,
         read_session: Session,
         esdb_client: EventStoreDBClient,
+        **kwargs,
     ) -> list[SQLModel]:
         if isinstance(source, (SQLModel, BaseModel)):
             obj = [cls.model_validate(source)]
@@ -87,6 +88,7 @@ class ActiveRecord(SQLModel):
             write_session,
             read_session,
             esdb_client,
+            **kwargs,
         )
 
         return created_entities


### PR DESCRIPTION
## Description

- Adds endpoint to retreive the lineage of a GC bundle from the EventStoreDB stream of database mutation events
- Accommodates splitting events by adding a `parent_entity_id` attribute to the `Event` object that is populated when a bundle splitting event occurs
- Returns lineage as a JSON of all changes to the GC through its lifecycle since issuance/import
- Adds frontend component to view graphic of lineage and download as JSON 

## Has This Been Tested?

- [x] Yes

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
